### PR TITLE
Change copyrighter name

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,6 @@ If you know how to fix an issue, or want something to be added, consider opening
 - [Zeno-](https://github.com/Zeno-)
 - [indriApollo](https://github.com/indriApollo)
 - [Billy-S](https://github.com/Billy-S)
-- [luk3yx](https://github.com/luk3yx)
 - Traxie21, the original creator of this mod (however, he/she does not have a GitHub account anymore).
 
 All those who contributed to the original mod (please see `init.lua`).

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ If you know how to fix an issue, or want something to be added, consider opening
 - [Zeno-](https://github.com/Zeno-)
 - [indriApollo](https://github.com/indriApollo)
 - [Billy-S](https://github.com/Billy-S)
+- [luk3yx](https://github.com/luk3yx)
 - Traxie21, the original creator of this mod (however, he/she does not have a GitHub account anymore).
 
 All those who contributed to the original mod (please see `init.lua`).
@@ -106,7 +107,7 @@ tp_enable_tpp_command = false
 ```
 Those values are the default values of the mod.   
 You can also go to your Minetest, Settings tab, All settings, Mods, and you'll find `tpr` there.    
-Or another way to do it, is changing the values in `settingstypes.txt`.
+Or another way to do it, is changing the values in `settingtypes.txt`.
 
 ## Installation
 - Unzip the archive, rename the folder to tpr and

--- a/config.lua
+++ b/config.lua
@@ -1,7 +1,7 @@
 --[[
 Configuration
 
-Copyright (C) 2015-2019  Michael Tomaino (PlatinumArts@gmail.com)
+Copyright (C) 2015-2019 ChaosWormz
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/init.lua
+++ b/init.lua
@@ -194,7 +194,7 @@ function tp.tpr_send(sender, receiver)
 		chat2.send_message(minetest.get_player_by_name(sender), S("Teleport request sent! It will timeout in @1 seconds", tp.timeout_delay), 0xFFFFFF)
 	end
 	minetest.chat_send_player(receiver, S("@1 is requesting to teleport to you. /tpy to accept", sender))
-	minetest.chat_send_player(sender, S("Teleport request sent! It will timeout in @1 seconds", timeout_delay))
+	minetest.chat_send_player(sender, S("Teleport request sent! It will timeout in @1 seconds", tp.timeout_delay))
 	-- Write name values to list and clear old values.
 		tp.tpr_list[receiver] = sender
 		-- Teleport timeout delay
@@ -266,7 +266,7 @@ function tp.tphr_send(sender, receiver)
 		chat2.send_message(minetest.get_player_by_name(sender), S("Teleport request sent! It will timeout in @1 seconds", tp.timeout_delay), 0xFFFFFF)
 	end
 	minetest.chat_send_player(receiver, S("@1 is requesting that you teleport to them. /tpy to accept; /tpn to deny", sender))
-	minetest.chat_send_player(sender, S("Teleport request sent! It will timeout in @1 seconds", timeout_delay))
+	minetest.chat_send_player(sender, S("Teleport request sent! It will timeout in @1 seconds", tp.timeout_delay))
 	-- Write name values to list and clear old values.
 		tp.tphr_list[receiver] = sender
 		-- Teleport timeout delay
@@ -381,8 +381,7 @@ end
 -- Teleport Accept Systems
 function tp.tpr_accept(name, param)
 	-- Check to prevent constant teleporting.
-	if not tp.tpr_list[name]
-	and not tp.tphr_list[name]
+	if not tp.tpr_list[name] and not tp.tphr_list[name] then
 		minetest.chat_send_player(name, S("Usage: /tpy allows you to accept teleport requests sent to you by other players"))
 		if minetest.get_modpath("chat2") then
 			chat2.send_message(minetest.get_player_by_name(name), S("Usage: /tpy allows you to accept teleport requests sent to you by other players"), 0xFFFFFF)

--- a/init.lua
+++ b/init.lua
@@ -1,5 +1,5 @@
 --[[
-Copyright (C) 2015-2019  Michael Tomaino (PlatinumArts@gmail.com)
+Copyright (C) 2015-2019 ChaosWormz
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public

--- a/locale/es.po
+++ b/locale/es.po
@@ -1,5 +1,5 @@
 # Spanish translation for Teleport Request.
-# Copyright (C) 2015-2019 Michael Tomaino and contributors.
+# Copyright (C) 2015-2019 ChaosWormz and contributors.
 # This file is distributed under under the same license as the Teleport Request package.
 # Panquesito7, 2019.
 

--- a/locale/template.pot
+++ b/locale/template.pot
@@ -1,5 +1,5 @@
 # Template translation for Teleport Request.
-# Copyright (C) 2015-2019 Michael Tomaino and contributors.
+# Copyright (C) 2015-2019 ChaosWormz and contributors.
 # This file is distributed under under the same license as the Teleport Request package.
 # Panquesito7, 2019.
 


### PR DESCRIPTION
Currently, the copyrighter name is the creator of the DWYWPL license.
Hence, the license was changed in the past, thus I changed the name to be `ChaosWormz`.