### PR TITLE
Fix crashing when unknown nodes are near

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -80,7 +80,8 @@ function tp.find_free_position_near(pos)
 	}
 	for _,d in pairs(tries) do
 		local p = vector.add(pos, d)
-		if not minetest.registered_nodes[minetest.get_node(p).name].walkable then
+		local def = minetest.registered_nodes[minetest.get_node(p).name]
+		if def and not def.walkable then
 			return p, true
 		end
 	end


### PR DESCRIPTION
Fixes crash:
```
2019-12-29 19:17:22: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'tpr' in callback on_chat_message(): .../tpr/init.lua:50: attempt to index a nil value
2019-12-29 19:17:22: ERROR[Main]: stack traceback:
2019-12-29 19:17:22: ERROR[Main]: 	.../tpr/init.lua:50: in function 'find_free_position_near'
2019-12-29 19:17:22: ERROR[Main]: 	.../tpr/init.lua:274: in function 'func'
2019-12-29 19:17:22: ERROR[Main]: 	.../minetest/builtin/game/chat.lua:55: in function <.../minetest/builtin/game/chat.lua:34>
```
Original issue: https://github.com/pandorabox-io/pandorabox.io/issues/393