### PR TITLE
Complete 1 task from TODO list

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,6 @@ For further information or help, see:
 https://wiki.minetest.net/Installing_Mods
 
 ## TODO
-- Make it so if a player attempts to teleport to coordinates within a protected area owned by another player, and that player is online, the owner receives a request to allow or deny the user from teleporting to their area.
 - Add limitations to /tpc which only allow a user to teleport X number of blocks. Prevents users from teleporting to the edge of the world.
 - Assess value in changing all tpr-based chat commands to one global command such as /tp to reduce the chance of confusion between tps_admin and the original mod (and also make it so people don't have to remember so many commands).
 - Create a better sound effect for teleport and apply it to all teleport methods (not just /tpc)

--- a/functions.lua
+++ b/functions.lua
@@ -189,11 +189,14 @@ function tp.tpr_send(sender, receiver)
 
 			-- Write name values to list and clear old values.
 			tp.tpr_list[receiver] = sender
+			tp.tpn_list[sender] = receiver
 
 			-- Teleport timeout delay
 			minetest.after(tp.timeout_delay, function(name)
-				if tp.tpr_list[name] then
+				if tp.tpr_list[name] and tp.tpn_list[sender] then
 					tp.tpr_list[name] = nil
+					tp.tpn_list[sender] = nil
+
 					minetest.chat_send_player(sender, S("Request timed-out."))
 					minetest.chat_send_player(receiver, S("Request timed-out."))
 
@@ -289,11 +292,14 @@ function tp.tphr_send(sender, receiver)
 
 			-- Write name values to list and clear old values.
 			tp.tphr_list[receiver] = sender
+			tp.tpn_list[sender] = receiver
 
 			-- Teleport timeout delay
 			minetest.after(tp.timeout_delay, function(name)
-				if tp.tphr_list[name] then
+				if tp.tphr_list[name] and tp.tpn_list[sender] then
 					tp.tphr_list[name] = nil
+					tp.tpn_list[sender] = nil
+
 					minetest.chat_send_player(sender, S("Request timed-out."))
 					minetest.chat_send_player(receiver, S("Request timed-out."))
 
@@ -376,6 +382,8 @@ function tp.tpc_send(sender, coordinates)
 							end
 
 							tp.tpc_list[area.owner] = sender
+							tp.tpn_list[sender] = area.owner
+
 							minetest.after(tp.timeout_delay, function(name)
 								if tp.tpc_list[name] then
 									tp.tpc_list[name] = nil
@@ -418,7 +426,7 @@ end
 function tp.tpr_deny(name)
 
 	if not tp.tpr_list[name] and not tp.tphr_list[name]
-	and not tp.tpc_list[name] then
+	and not tp.tpc_list[name] and not tp.tpn_list[name] then
 		minetest.chat_send_player(name, S("Usage: /tpn allows you to deny teleport/area requests sent to you by other players."))
 		if minetest.get_modpath("chat2") then
 			chat2.send_message(minetest.get_player_by_name(name), S("Usage: /tpn allows you to deny teleport/area requests sent to you by other players."), 0xFFFFFF)
@@ -432,10 +440,13 @@ function tp.tpr_deny(name)
 		minetest.chat_send_player(name2, S("Area request denied."))
 		minetest.chat_send_player(name, S("You denied the request @1 sent you.", name2))
 		tp.tpc_list[name] = nil
+
 		if minetest.get_modpath("chat2") then
 			chat2.send_message(minetest.get_player_by_name(name2), S("Area request denied."), 0xFFFFFF)
 			chat2.send_message(minetest.get_player_by_name(name), S("You denied the request @1 sent you.", name2), 0xFFFFFF)
 		end
+
+		tp.tpn_list[name2] = nil
 		return
 	end
 
@@ -451,6 +462,9 @@ function tp.tpr_deny(name)
 
 		tp.tpr_list[name] = nil
 
+		-- Don't re-deny the request.
+		tp.tpn_list[name2] = nil
+
 	elseif tp.tphr_list[name] then
 		name2 = tp.tphr_list[name]
 		minetest.chat_send_player(name2, S("Teleport request denied."))
@@ -461,6 +475,31 @@ function tp.tpr_deny(name)
 		end
 
 		tp.tphr_list[name] = nil
+
+		-- Don't re-deny the request.
+		tp.tpn_list[name2] = nil
+
+	-- Denying self-sent requests
+	elseif tp.tpn_list[name] then
+		name2 = tp.tpn_list[name]
+		minetest.chat_send_player(name, S("You denied your request sent to @1.", name2))
+		minetest.chat_send_player(name2, S("@1 denied their request sent to you.", name))
+		if minetest.get_modpath("chat2") then
+			chat2.send_message(minetest.get_player_by_name(name), S("You denied your request sent to @1.", name2), 0xFFFFFF)
+			chat2.send_message(minetest.get_player_by_name(name2), S("@1 denied their request sent to you.", name), 0xFFFFFF)
+		end
+
+		if tp.tpr_list[name2] then
+			tp.tpr_list[name2] = nil
+
+		elseif tp.tphr_list[name2] then
+			tp.tphr_list[name2] = nil
+
+		elseif tp.tpc_list[name2] then
+			tp.tpc_list[name2] = nil
+		end
+
+		tp.tpn_list[name] = nil
 		return
 	end
 end
@@ -558,6 +597,12 @@ function tp.tpr_accept(name)
 
 	-- Avoid abusing with area requests
 	target_coords = nil
+
+	-- Don't allow re-denying requests.
+	if tp.tpn_list[name] or tp.tpn_list[name2] then
+		tp.tpn_list[name] = nil
+		tp.tpn_list[name2] = nil
+	end
 
 	minetest.chat_send_player(name, chatmsg)
 	if minetest.get_modpath("chat2") then

--- a/functions.lua
+++ b/functions.lua
@@ -189,14 +189,11 @@ function tp.tpr_send(sender, receiver)
 
 			-- Write name values to list and clear old values.
 			tp.tpr_list[receiver] = sender
-			tp.tpn_list[sender] = receiver
 
 			-- Teleport timeout delay
 			minetest.after(tp.timeout_delay, function(name)
-				if tp.tpr_list[name] and tp.tpn_list[sender] then
+				if tp.tpr_list[name] then
 					tp.tpr_list[name] = nil
-					tp.tpn_list[sender] = nil
-
 					minetest.chat_send_player(sender, S("Request timed-out."))
 					minetest.chat_send_player(receiver, S("Request timed-out."))
 
@@ -292,14 +289,11 @@ function tp.tphr_send(sender, receiver)
 
 			-- Write name values to list and clear old values.
 			tp.tphr_list[receiver] = sender
-			tp.tpn_list[sender] = receiver
 
 			-- Teleport timeout delay
 			minetest.after(tp.timeout_delay, function(name)
-				if tp.tphr_list[name] and tp.tpn_list[sender] then
+				if tp.tphr_list[name] then
 					tp.tphr_list[name] = nil
-					tp.tpn_list[sender] = nil
-
 					minetest.chat_send_player(sender, S("Request timed-out."))
 					minetest.chat_send_player(receiver, S("Request timed-out."))
 
@@ -382,8 +376,6 @@ function tp.tpc_send(sender, coordinates)
 							end
 
 							tp.tpc_list[area.owner] = sender
-							tp.tpn_list[sender] = area.owner
-
 							minetest.after(tp.timeout_delay, function(name)
 								if tp.tpc_list[name] then
 									tp.tpc_list[name] = nil
@@ -426,7 +418,7 @@ end
 function tp.tpr_deny(name)
 
 	if not tp.tpr_list[name] and not tp.tphr_list[name]
-	and not tp.tpc_list[name] and not tp.tpn_list[name] then
+	and not tp.tpc_list[name] then
 		minetest.chat_send_player(name, S("Usage: /tpn allows you to deny teleport/area requests sent to you by other players."))
 		if minetest.get_modpath("chat2") then
 			chat2.send_message(minetest.get_player_by_name(name), S("Usage: /tpn allows you to deny teleport/area requests sent to you by other players."), 0xFFFFFF)
@@ -440,13 +432,10 @@ function tp.tpr_deny(name)
 		minetest.chat_send_player(name2, S("Area request denied."))
 		minetest.chat_send_player(name, S("You denied the request @1 sent you.", name2))
 		tp.tpc_list[name] = nil
-
 		if minetest.get_modpath("chat2") then
 			chat2.send_message(minetest.get_player_by_name(name2), S("Area request denied."), 0xFFFFFF)
 			chat2.send_message(minetest.get_player_by_name(name), S("You denied the request @1 sent you.", name2), 0xFFFFFF)
 		end
-
-		tp.tpn_list[name2] = nil
 		return
 	end
 
@@ -462,9 +451,6 @@ function tp.tpr_deny(name)
 
 		tp.tpr_list[name] = nil
 
-		-- Don't re-deny the request.
-		tp.tpn_list[name2] = nil
-
 	elseif tp.tphr_list[name] then
 		name2 = tp.tphr_list[name]
 		minetest.chat_send_player(name2, S("Teleport request denied."))
@@ -475,31 +461,6 @@ function tp.tpr_deny(name)
 		end
 
 		tp.tphr_list[name] = nil
-
-		-- Don't re-deny the request.
-		tp.tpn_list[name2] = nil
-
-	-- Denying self-sent requests
-	elseif tp.tpn_list[name] then
-		name2 = tp.tpn_list[name]
-		minetest.chat_send_player(name, S("You denied your request sent to @1.", name2))
-		minetest.chat_send_player(name2, S("@1 denied their request sent to you.", name))
-		if minetest.get_modpath("chat2") then
-			chat2.send_message(minetest.get_player_by_name(name), S("You denied your request sent to @1.", name2), 0xFFFFFF)
-			chat2.send_message(minetest.get_player_by_name(name2), S("@1 denied their request sent to you.", name), 0xFFFFFF)
-		end
-
-		if tp.tpr_list[name2] then
-			tp.tpr_list[name2] = nil
-
-		elseif tp.tphr_list[name2] then
-			tp.tphr_list[name2] = nil
-
-		elseif tp.tpc_list[name2] then
-			tp.tpc_list[name2] = nil
-		end
-
-		tp.tpn_list[name] = nil
 		return
 	end
 end
@@ -597,12 +558,6 @@ function tp.tpr_accept(name)
 
 	-- Avoid abusing with area requests
 	target_coords = nil
-
-	-- Don't allow re-denying requests.
-	if tp.tpn_list[name] or tp.tpn_list[name2] then
-		tp.tpn_list[name] = nil
-		tp.tpn_list[name2] = nil
-	end
 
 	minetest.chat_send_player(name, chatmsg)
 	if minetest.get_modpath("chat2") then

--- a/functions.lua
+++ b/functions.lua
@@ -485,7 +485,7 @@ function tp.tpr_accept(name)
 			name2 = tp.tpc_list[name]
 			source = minetest.get_player_by_name(name)
 			target = minetest.get_player_by_name(name2)
-			chatmsg = S("@1 is teleporting to your protected area @2.", name2, minetest.pos_to_string(target_coords))
+			chatmsg = S("@1 is teleporting to your protected area @2.", name2, minetest.pos_to_string(tpc_target_coords[name]))
 			tp.tpc_list[name] = nil
 		else
 			return

--- a/functions.lua
+++ b/functions.lua
@@ -420,9 +420,7 @@ function tp.tpr_deny(name)
 		name2 = tp.tpc_list[name]
 		minetest.chat_send_player(name2, S("Area request denied."))
 		minetest.chat_send_player(name, S("You denied the request @1 sent you.", name2))
-		for _, area in pairs(areas:getAreasAtPos(target_coords)) do
-			tp.tpc_list[area.owner] = nil
-		end
+		tp.tpc_list[name] = nil
 		if minetest.get_modpath("chat2") then
 			chat2.send_message(minetest.get_player_by_name(name2), S("Area request denied."), 0xFFFFFF)
 			chat2.send_message(minetest.get_player_by_name(name), S("You denied the request @1 sent you.", name2), 0xFFFFFF)
@@ -486,9 +484,7 @@ function tp.tpr_accept(name)
 			source = minetest.get_player_by_name(name)
 			target = minetest.get_player_by_name(name2)
 			chatmsg = S("@1 is teleporting to your protected area @2.", name2, minetest.pos_to_string(target_coords))
-			for _, area in pairs(areas:getAreasAtPos(target_coords)) do
-				tp.tpc_list[area.owner] = nil
-			end
+			tp.tpc_list[name] = nil
 		else
 			return
 		end
@@ -496,9 +492,7 @@ function tp.tpr_accept(name)
 		-- If source or target are not present, abort request.
 		if not source or not target then
 			minetest.chat_send_player(name, S("@1 is not online right now.", name2))
-			for _, area in pairs(areas:getAreasAtPos(target_coords)) do
-				tp.tpc_list[area.owner] = nil
-			end
+			tp.tpc_list[name] = nil
 			if minetest.get_modpath("chat2") then
 				chat2.send_message(minetest.get_player_by_name(name), S("@1 is not online right now.", name2), 0xFFFFFF)
 			end

--- a/functions.lua
+++ b/functions.lua
@@ -361,7 +361,6 @@ function tp.tpc_send(sender, coordinates)
 
 								chat2.send_message(minetest.get_player_by_name(area.owner), S("@1 is requesting to teleport to a protected area" ..
 								" of yours @2.", sender, minetest.pos_to_string(target_coords)), 0xFFFFFF)
-								return
 							end
 
 							tp.tpc_list[area.owner] = sender

--- a/functions.lua
+++ b/functions.lua
@@ -179,12 +179,12 @@ function tp.tpr_send(sender, receiver)
 			end
 
 			if minetest.get_modpath("chat2") then
-				chat2.send_message(minetest.get_player_by_name(receiver), S("@1 is requesting to teleport to you. /tpy to accept", sender), 0xFFFFFF)
-				chat2.send_message(minetest.get_player_by_name(sender), S("Teleport request sent! It will timeout in @1 seconds", tp.timeout_delay), 0xFFFFFF)
+				chat2.send_message(minetest.get_player_by_name(receiver), S("@1 is requesting to teleport to you. /tpy to accept.", sender), 0xFFFFFF)
+				chat2.send_message(minetest.get_player_by_name(sender), S("Teleport request sent! It will timeout in @1 seconds.", tp.timeout_delay), 0xFFFFFF)
 			end
 
-			minetest.chat_send_player(receiver, S("@1 is requesting to teleport to you. /tpy to accept", sender))
-			minetest.chat_send_player(sender, S("Teleport request sent! It will timeout in @1 seconds", tp.timeout_delay))
+			minetest.chat_send_player(receiver, S("@1 is requesting to teleport to you. /tpy to accept.", sender))
+			minetest.chat_send_player(sender, S("Teleport request sent! It will timeout in @1 seconds.", tp.timeout_delay))
 
 			-- Write name values to list and clear old values.
 			tp.tpr_list[receiver] = sender
@@ -209,9 +209,9 @@ function tp.tphr_send(sender, receiver)
 	-- Compatibility with beerchat
 		if minetest.get_modpath("beerchat") and not minetest.check_player_privs(sender, {tp_admin = true}) then
 			if not minetest.get_player_by_name(receiver) then
-				minetest.chat_send_player(sender, S("There is no player by that name. Keep in mind this is case-sensitive, and the player must be online"))
+				minetest.chat_send_player(sender, S("There is no player by that name. Keep in mind this is case-sensitive, and the player must be online."))
 				if minetest.get_modpath("chat2") then
-					chat2.send_message(minetest.get_player_by_name(sender), S("There is no player by that name. Keep in mind this is case-sensitive, and the player must be online"), 0xFFFFFF)
+					chat2.send_message(minetest.get_player_by_name(sender), S("There is no player by that name. Keep in mind this is case-sensitive, and the player must be online."), 0xFFFFFF)
 				end
 				return
 			end
@@ -236,9 +236,9 @@ function tp.tphr_send(sender, receiver)
 			end
 
 			if not minetest.get_player_by_name(receiver) then
-				minetest.chat_send_player(sender, S("There is no player by that name. Keep in mind this is case-sensitive, and the player must be online"))
+				minetest.chat_send_player(sender, S("There is no player by that name. Keep in mind this is case-sensitive, and the player must be online."))
 					if minetest.get_modpath("chat2") then
-						chat2.send_message(minetest.get_player_by_name(sender), S("There is no player by that name. Keep in mind this is case-sensitive, and the player must be online"), 0xFFFFFF)
+						chat2.send_message(minetest.get_player_by_name(sender), S("There is no player by that name. Keep in mind this is case-sensitive, and the player must be online."), 0xFFFFFF)
 					end
 				return
 			end
@@ -261,9 +261,9 @@ function tp.tphr_send(sender, receiver)
 			end
 
 			if not minetest.get_player_by_name(receiver) then
-				minetest.chat_send_player(sender, S("There is no player by that name. Keep in mind this is case-sensitive, and the player must be online"))
+				minetest.chat_send_player(sender, S("There is no player by that name. Keep in mind this is case-sensitive, and the player must be online."))
 					if minetest.get_modpath("chat2") then
-						chat2.send_message(minetest.get_player_by_name(sender), S("There is no player by that name. Keep in mind this is case-sensitive, and the player must be online"), 0xFFFFFF)
+						chat2.send_message(minetest.get_player_by_name(sender), S("There is no player by that name. Keep in mind this is case-sensitive, and the player must be online."), 0xFFFFFF)
 					end
 				return
 			end
@@ -279,12 +279,12 @@ function tp.tphr_send(sender, receiver)
 			end
 
 			if minetest.get_modpath("chat2") then
-				chat2.send_message(minetest.get_player_by_name(receiver), S("@1 is requesting that you teleport to them. /tpy to accept; /tpn to deny", sender), 0xFFFFFF)
-				chat2.send_message(minetest.get_player_by_name(sender), S("Teleport request sent! It will timeout in @1 seconds", tp.timeout_delay), 0xFFFFFF)
+				chat2.send_message(minetest.get_player_by_name(receiver), S("@1 is requesting that you teleport to them. /tpy to accept; /tpn to deny.", sender), 0xFFFFFF)
+				chat2.send_message(minetest.get_player_by_name(sender), S("Teleport request sent! It will timeout in @1 seconds.", tp.timeout_delay), 0xFFFFFF)
 			end
 
-			minetest.chat_send_player(receiver, S("@1 is requesting that you teleport to them. /tpy to accept; /tpn to deny", sender))
-			minetest.chat_send_player(sender, S("Teleport request sent! It will timeout in @1 seconds", tp.timeout_delay))
+			minetest.chat_send_player(receiver, S("@1 is requesting that you teleport to them. /tpy to accept; /tpn to deny.", sender))
+			minetest.chat_send_player(sender, S("Teleport request sent! It will timeout in @1 seconds.", tp.timeout_delay))
 
 			-- Write name values to list and clear old values.
 			tp.tphr_list[receiver] = sender
@@ -305,10 +305,10 @@ function tp.tphr_send(sender, receiver)
 		end, receiver)
 end
 
-function tp.tpc_send(player, coordinates)
+function tp.tpc_send(sender, coordinates)
 
 	local posx,posy,posz = string.match(coordinates, "^(-?%d+), (-?%d+), (-?%d+)$")
-	local pname = minetest.get_player_by_name(player)
+	local pname = minetest.get_player_by_name(sender)
 
 	if posx ~= nil or posy ~= nil or posz ~= nil then
 	  posx = tonumber(posx) + 0.0
@@ -317,9 +317,9 @@ function tp.tpc_send(player, coordinates)
 	end
 
 	if posx==nil or posy==nil or posz==nil or string.len(posx) > 6 or string.len(posy) > 6 or string.len(posz) > 6 then
-		minetest.chat_send_player(player, S("Usage: /tpc <x, y, z>"))
+		minetest.chat_send_player(sender, S("Usage: /tpc <x, y, z>"))
 		if minetest.get_modpath("chat2") then
-			chat2.send_message(minetest.get_player_by_name(player), S("Usage: /tpc <x, y, z>"), 0xFFFFFF)
+			chat2.send_message(minetest.get_player_by_name(sender), S("Usage: /tpc <x, y, z>"), 0xFFFFFF)
 		end
 		return nil
 	end
@@ -327,50 +327,74 @@ function tp.tpc_send(player, coordinates)
 	target_coords = {x=posx, y=posy, z=posz}
 
 	if tp.can_teleport(target_coords) == false then
-		minetest.chat_send_player(player, S("You cannot teleport to a location outside the map!"))
-	if minetest.get_modpath("chat2") then
-		chat2.send_message(minetest.get_player_by_name(player), S("You cannot teleport to a location outside the map!"), 0xFFFFFF)
-	end
+		minetest.chat_send_player(sender, S("You cannot teleport to a location outside the map!"))
+		if minetest.get_modpath("chat2") then
+			chat2.send_message(minetest.get_player_by_name(sender), S("You cannot teleport to a location outside the map!"), 0xFFFFFF)
+		end
 		return nil
 	end
 
 	-- If the area is protected, reject the user's request to teleport to these coordinates
-	-- In future release we'll actually query the player who owns the area, if they're online, and ask for their permission.
 	-- Admin user (priv "tp_admin") overrides all protection
 	if minetest.check_player_privs(pname, {tp_admin = true}) then
-		tp.tpc_teleport_player(player)
-		minetest.chat_send_player(player, S("Teleporting to: @1, @2, @3", posx, posy, posz))
+		tp.tpc_teleport_player(sender)
+		target_coords = nil
+		minetest.chat_send_player(sender, S("Teleporting to: @1, @2, @3", posx, posy, posz))
 		if minetest.get_modpath("chat2") then
-			chat2.send_message(minetest.get_player_by_name(player), S("Teleporting to: @1, @2, @3", posx, posy, posz), 0xFFFFFF)
+			chat2.send_message(minetest.get_player_by_name(sender), S("Teleporting to: @1, @2, @3", posx, posy, posz), 0xFFFFFF)
 		end
 	else
 		if minetest.check_player_privs(pname, {tp_tpc = true}) then
-			local protected = minetest.is_protected(target_coords, player)
+			local protected = minetest.is_protected(target_coords, sender)
 			if protected then
-				minetest.record_protection_violation(target_coords, player)
+				if minetest.get_modpath("areas") then
+					if table.concat(areas:getNodeOwners(target_coords)) then
+						minetest.chat_send_player(sender, S("Area request sent! Waiting for @1 to accept your request." ..
+						" It will timeout in @2 seconds.", table.concat(areas:getNodeOwners(target_coords), ", or "), tp.timeout_delay))
+						minetest.chat_send_player(table.concat(areas:getNodeOwners(target_coords)), S("@1 is requesting to teleport to a protected area " ..
+						" of yours @2.", sender, minetest.pos_to_string(target_coords)))
+
+						if minetest.get_modpath("chat2") then
+							chat2.send_message(minetest.get_player_by_name(sender), S("Area request sent! Waiting for @1 to accept your request." ..
+							" It will timeout in @2 seconds.", table.concat(areas:getNodeOwners(target_coords), ", or "), tp.timeout_delay), 0xFFFFFF)
+
+							chat2.send_message(minetest.get_player_by_name(table.concat(areas:getNodeOwners(target_coords))), S("@1 is requesting to teleport to a protected area "..
+							" of yours @2.", sender, minetest.pos_to_string(target_coords)), 0xFFFFFF)
+						end
+
+						tp.tpc_list[table.concat(areas:getNodeOwners(target_coords))] = sender
+						minetest.after(tp.timeout_delay, function(name)
+							if tp.tpc_list[name] then
+								tp.tpc_list[name] = nil
+								minetest.chat_send_player(sender, S("Request timed-out."))
+								minetest.chat_send_player(table.concat(areas:getNodeOwners(target_coords)), S("Request timed-out."))
+
+								if minetest.get_modpath("chat2") then
+									chat2.send_message(minetest.get_player_by_name(sender), S("Request timed-out."), 0xFFFFFF)
+									chat2.send_message(minetest.get_player_by_name(table.concat(areas:getNodeOwners(target_coords))), S("Request timed-out."), 0xFFFFFF)
+								end
+								return
+							end
+						end, table.concat(areas:getNodeOwners(target_coords)))
+				else
+					minetest.record_protection_violation(target_coords, sender)
+					end
+				else
+					minetest.record_protection_violation(target_coords, sender)
+				end
 				return
 			end
 
-			 if minetest.get_modpath("areas") then
-				if not areas:canInteract(target_coords, player) then
-					local owners = areas:getNodeOwners(target_coords)
-					minetest.chat_send_player(player, S("Error: @1 is protected by @2.", minetest.pos_to_string(target_coords), table.concat(owners, ", ")))
-					if minetest.get_modpath("chat2") then
-						chat2.send_message(minetest.get_player_by_name(player), S("Error: @1 is protected by @2.", minetest.pos_to_string(target_coords), table.concat(owners, ", ")), 0xFFFFFF)
-					end
-					return
-				end
-			end
-
-			tp.tpc_teleport_player(player)
-			minetest.chat_send_player(player, S("Teleporting to: @1, @2, @3", posx, posy, posz))
+			tp.tpc_teleport_player(sender)
+			target_coords = nil
+			minetest.chat_send_player(sender, S("Teleporting to: @1, @2, @3", posx, posy, posz))
 			if minetest.get_modpath("chat2") then
-				chat2.send_message(minetest.get_player_by_name(player), S("Teleporting to: @1, @2, @3", posx, posy, posz), 0xFFFFFF)
+				chat2.send_message(minetest.get_player_by_name(sender), S("Teleporting to: @1, @2, @3", posx, posy, posz), 0xFFFFFF)
 			end
 		else
-			minetest.chat_send_player(player, S("Error: You do not have permission to teleport to those coordinates."))
+			minetest.chat_send_player(sender, S("Error: You do not have permission to teleport to those coordinates."))
 			if minetest.get_modpath("chat2") then
-				chat2.send_message(minetest.get_player_by_name(player), S("Error: You do not have permission to teleport to those coordinates."), 0xFFFFFF)
+				chat2.send_message(minetest.get_player_by_name(sender), S("Error: You do not have permission to teleport to those coordinates."), 0xFFFFFF)
 			end
 			return
 		end
@@ -378,6 +402,30 @@ function tp.tpc_send(player, coordinates)
 end
 
 function tp.tpr_deny(name)
+
+	if not tp.tpr_list[name] and not tp.tphr_list[name]
+	and not tp.tpc_list[name] then
+		minetest.chat_send_player(name, S("Usage: /tpn allows you to deny teleport/area requests sent to you by other players."))
+		if minetest.get_modpath("chat2") then
+			chat2.send_message(minetest.get_player_by_name(name), S("Usage: /tpn allows you to deny teleport/area requests sent to you by other players."), 0xFFFFFF)
+		end
+		return
+	end
+
+	-- Area requests
+	if tp.tpc_list[name] then
+		name2 = tp.tpc_list[name]
+		minetest.chat_send_player(name2, S("Area request denied."))
+		minetest.chat_send_player(name, S("You denied the request @1 sent you.", name2))
+		tp.tpc_list[name] = nil
+		if minetest.get_modpath("chat2") then
+			chat2.send_message(minetest.get_player_by_name(name2), S("Area request denied."), 0xFFFFFF)
+			chat2.send_message(minetest.get_player_by_name(name), S("You denied the request @1 sent you.", name2), 0xFFFFFF)
+		end
+		return
+	end
+
+	-- Teleport requests
 	if tp.tpr_list[name] then
 		name2 = tp.tpr_list[name]
 		minetest.chat_send_player(name2, S("Teleport request denied."))
@@ -386,6 +434,7 @@ function tp.tpr_deny(name)
 			chat2.send_message(minetest.get_player_by_name(name2), S("Teleport request denied."), 0xFFFFFF)
 			chat2.send_message(minetest.get_player_by_name(name), S("You denied the request @1 sent you.", name2), 0xFFFFFF)
 		end
+
 		tp.tpr_list[name] = nil
 
 	elseif tp.tphr_list[name] then
@@ -396,13 +445,8 @@ function tp.tpr_deny(name)
 			chat2.send_message(minetest.get_player_by_name(name2), S("Teleport request denied."), 0xFFFFFF)
 			chat2.send_message(minetest.get_player_by_name(name), S("You denied the request @1 sent you.", name2), 0xFFFFFF)
 		end
-		tp.tphr_list[name] = nil
 
-	else
-		minetest.chat_send_player(name, S("Usage: /tpn allows you to deny teleport requests sent to you by other players."))
-		if minetest.get_modpath("chat2") then
-			chat2.send_message(minetest.get_player_by_name(name), S("Usage: /tpn allows you to deny teleport requests sent to you by other players."), 0xFFFFFF)
-		end
+		tp.tphr_list[name] = nil
 		return
 	end
 end
@@ -410,15 +454,53 @@ end
 -- Teleport Accept Systems
 function tp.tpr_accept(name)
 
-	-- Check to prevent constant teleporting.
-	if not tp.tpr_list[name] and not tp.tphr_list[name] then
-		minetest.chat_send_player(name, S("Usage: /tpy allows you to accept teleport requests sent to you by other players"))
+	-- Check to prevent constant teleporting
+	if not tp.tpr_list[name] and not tp.tphr_list[name]
+	and not tp.tpc_list[name] then
+		minetest.chat_send_player(name, S("Usage: /tpy allows you to accept teleport/area requests sent to you by other players."))
 		if minetest.get_modpath("chat2") then
-			chat2.send_message(minetest.get_player_by_name(name), S("Usage: /tpy allows you to accept teleport requests sent to you by other players"), 0xFFFFFF)
+			chat2.send_message(minetest.get_player_by_name(name), S("Usage: /tpy allows you to accept teleport/area requests sent to you by other players."), 0xFFFFFF)
 		end
 		return
 	end
 
+	-- Area requests
+	if tp.tpc_list[name] then
+
+		if tp.tpc_list[name] then
+			name2 = tp.tpc_list[name]
+			source = minetest.get_player_by_name(name)
+			target = minetest.get_player_by_name(name2)
+			chatmsg = S("@1 is teleporting to your protected area @2.", name2, minetest.pos_to_string(target_coords))
+			tp.tpc_list[name] = nil
+		else
+			return
+		end
+
+		-- If sender is not present, abort request.
+		if not source or not target then
+			minetest.chat_send_player(name, S("@1 is not online right now.", name2))
+			if minetest.get_modpath("chat2") then
+				chat2.send_message(minetest.get_player_by_name(name), S("@1 is not online right now.", name2), 0xFFFFFF)
+			end
+			return
+		end
+
+		tp.tpp_teleport_player(name2, target_coords)
+		minetest.chat_send_player(name, chatmsg)
+		minetest.chat_send_player(name2, S("Request Accepted!"))
+
+		-- Avoid abusing with area requests
+		target_coords = nil
+
+		if minetest.get_modpath("chat2") then
+			chat2.send_message(minetest.get_player_by_name(name2), S("Request Accepted!"), 0xFFFFFF)
+			chat2.send_message(minetest.get_player_by_name(name), chatmsg, 0xFFFFFF)
+			return
+		end
+	end
+
+	-- Teleport requests.
 	if tp.tpr_list[name] then
 		name2 = tp.tpr_list[name]
 		source = minetest.get_player_by_name(name)
@@ -439,14 +521,17 @@ function tp.tpr_accept(name)
 	-- Could happen if either player disconnects (or timeout); if so just abort
 	if not source
 	or not target then
-		minetest.chat_send_player(name, S("@1 doesn't exist, or just disconnected/left (by timeout).", name2))
+		minetest.chat_send_player(name, S("@1 is not online right now.", name2))
 		if minetest.get_modpath("chat2") then
-			chat2.send_message(minetest.get_player_by_name(name), S("@1 doesn't exist, or just disconnected/left (by timeout).", name2), 0xFFFFFF)
+			chat2.send_message(minetest.get_player_by_name(name), S("@1 is not online right now.", name2), 0xFFFFFF)
 		end
 		return
 	end
 
 	tp.tpr_teleport_player()
+
+	-- Avoid abusing with area requests
+	target_coords = nil
 
 	minetest.chat_send_player(name, chatmsg)
 	if minetest.get_modpath("chat2") then
@@ -521,6 +606,9 @@ function tp.tpj(player, param)
 		return
 	end
 	tp.tpc_teleport_player(player)
+
+	-- Avoid abusing with area requests
+	target_coords = nil
 end
 
 -- Evade

--- a/functions.lua
+++ b/functions.lua
@@ -349,7 +349,7 @@ function tp.tpc_send(sender, coordinates)
 			if protected then
 				if minetest.get_modpath("areas") then
 					for _, area in pairs(areas:getAreasAtPos(target_coords)) do
-						if area.owner then
+						if minetest.get_player_by_name(area.owner) then -- Check if area owners are online
 							minetest.chat_send_player(sender, S("Area request sent! Waiting for @1 to accept your request." ..
 							" It will timeout in @2 seconds.", table.concat(areas:getNodeOwners(target_coords), S(", or ")), tp.timeout_delay))
 							minetest.chat_send_player(area.owner, S("@1 is requesting to teleport to a protected area" ..
@@ -361,6 +361,7 @@ function tp.tpc_send(sender, coordinates)
 
 								chat2.send_message(minetest.get_player_by_name(area.owner), S("@1 is requesting to teleport to a protected area" ..
 								" of yours @2.", sender, minetest.pos_to_string(target_coords)), 0xFFFFFF)
+								return
 							end
 
 							tp.tpc_list[area.owner] = sender
@@ -470,6 +471,15 @@ function tp.tpr_accept(name)
 
 	-- Area requests
 	if tp.tpc_list[name] then
+
+		-- If "target_coords" is nil, abort request.
+		if not target_coords then
+			minetest.chat_send_player(name, S("Usage: /tpy allows you to accept teleport/area requests sent to you by other players."))
+			if minetest.get_modpath("chat2") then
+				chat2.send_message(minetest.get_player_by_name(name), S("Usage: /tpy allows you to accept teleport/area requests sent to you by other players."), 0xFFFFFF)
+			end
+			return
+		end
 
 		if tp.tpc_list[name] then
 			name2 = tp.tpc_list[name]

--- a/init.lua
+++ b/init.lua
@@ -33,7 +33,8 @@ local S = dofile(MP.."/intllib.lua")
 tp = {
 	intllib = S,
 	tpr_list = {},
-	tphr_list = {}
+	tphr_list = {},
+	tpc_list = {}
 }
 
 -- Clear requests when the player leaves
@@ -45,6 +46,12 @@ minetest.register_on_leaveplayer(function(name)
 
 	if tp.tphr_list[name] then
 		tp.tphr_list[name] = nil
+		return
+	end
+
+	-- Area requests
+	if tp.tpc_list[name] then
+		tp.tpc_list[name] = nil
 		return
 	end
 end)

--- a/init.lua
+++ b/init.lua
@@ -34,8 +34,7 @@ tp = {
 	intllib = S,
 	tpr_list = {},
 	tphr_list = {},
-	tpc_list = {},
-	tpn_list = {}
+	tpc_list = {}
 }
 
 -- Clear requests when the player leaves
@@ -53,11 +52,6 @@ minetest.register_on_leaveplayer(function(name)
 	-- Area requests
 	if tp.tpc_list[name] then
 		tp.tpc_list[name] = nil
-		return
-	end
-
-	if tp.tpn_list[name] then
-		tp.tpn_list[name] = nil
 		return
 	end
 end)

--- a/init.lua
+++ b/init.lua
@@ -34,7 +34,8 @@ tp = {
 	intllib = S,
 	tpr_list = {},
 	tphr_list = {},
-	tpc_list = {}
+	tpc_list = {},
+	tpn_list = {}
 }
 
 -- Clear requests when the player leaves
@@ -52,6 +53,11 @@ minetest.register_on_leaveplayer(function(name)
 	-- Area requests
 	if tp.tpc_list[name] then
 		tp.tpc_list[name] = nil
+		return
+	end
+
+	if tp.tpn_list[name] then
+		tp.tpn_list[name] = nil
 		return
 	end
 end)

--- a/locale/es.po
+++ b/locale/es.po
@@ -94,11 +94,15 @@ msgstr ", o a "
 
 #: init.lua
 msgid "@1 is requesting to teleport to a protected area of yours @2."
-msgstr "@1 solicita teletransportarse a una área protegida tuya @2."
+msgstr "@1 solicita teletransportarse a un área protegida tuya @2."
 
 #: init.lua
 msgid "Error: You do not have permission to teleport to those coordinates."
 msgstr "Error: No tienes permiso para teletransportarte a esas coordenadas."
+
+#: init.lua
+msgid "Usage: /tpn allows you to deny teleport/area requests sent to you by other players."
+msgstr "Uso: /tpn te permite denegar solicitudes enviadas para ti de otros jugadores."
 
 #: init.lua
 msgid "Teleport request denied."
@@ -109,8 +113,12 @@ msgid "You denied the request @1 sent you."
 msgstr "Tú denegaste la solicitud de teletransporte que @1 te mando."
 
 #: init.lua
-msgid "Usage: /tpn allows you to deny teleport/area requests sent to you by other players."
-msgstr "Uso: /tpn te permite denegar solicitudes enviadas para ti de otros jugadores."
+msgid "You denied your request sent to @1."
+msgstr "Tú denegaste la solicitud de teletransporte enviada a @1."
+
+#: init.lua
+msgid "@1 denied their request sent to you."
+msgstr "@1 denego su solicitud de teletransporte enviada a usted."
 
 #: init.lua
 msgid "Area request denied."

--- a/locale/es.po
+++ b/locale/es.po
@@ -38,7 +38,7 @@ msgstr "Uso: /tpr <jugador>"
 
 #: init.lua
 msgid "There is no player by that name. Keep in mind this is case-sensitive, and the player must be online."
-msgstr "No hay jugador con ese nombre. Tenga en cuenta que esto es caso-sensitivo, y el jugador debe de estar én linea."
+msgstr "No hay jugador con ese nombre. Tenga en cuenta que esto es caso-sensitivo, y el jugador debe de estar én línea."
 
 #: init.lua
 msgid "Teleport request denied, player is in the gamehub!"
@@ -86,7 +86,11 @@ msgstr "Teletransportandose a: @1, @2, @3"
 
 #: init.lua
 msgid "Area request sent! Waiting for @1 to accept your request. It will timeout in @2 seconds."
-msgstr "Solicitud de área enviada! Esperando a @1 que acepte tu solicitud. Se agotara en @2 segundos."
+msgstr "¡Solicitud de área enviada! Esperando a @1 que acepte tu solicitud. Se agotara en @2 segundos."
+
+#: init.lua
+msgid ", or "
+msgstr ", o a "
 
 #: init.lua
 msgid "@1 is requesting to teleport to a protected area of yours @2."
@@ -122,7 +126,7 @@ msgstr "@1 se esta teletransportando a tu área protegida @2."
 
 #: init.lua
 msgid "@1 is not online right now."
-msgstr "@1 no esta en linea ahora mismo."
+msgstr "@1 no esta en línea ahora mismo."
 
 #: init.lua
 msgid "Request Accepted!"

--- a/locale/es.po
+++ b/locale/es.po
@@ -1,7 +1,7 @@
 # Spanish translation for Teleport Request.
 # Copyright (C) 2014-2020 ChaosWormz and contributors.
 # This file is distributed under under the same license as the Teleport Request package.
-# David Leal <halfpacho@gmail.com>, 2019.
+# David Leal <halfpacho@gmail.com>, 2019-2020.
 
 msgid ""
 msgstr ""
@@ -37,7 +37,7 @@ msgid "Usage: /tpr <Player name>"
 msgstr "Uso: /tpr <jugador>"
 
 #: init.lua
-msgid "There is no player by that name. Keep in mind this is case-sensitive, and the player must be online"
+msgid "There is no player by that name. Keep in mind this is case-sensitive, and the player must be online."
 msgstr "No hay jugador con ese nombre. Tenga en cuenta que esto es caso-sensitivo, y el jugador debe de estar én linea."
 
 #: init.lua
@@ -49,12 +49,12 @@ msgid "You are teleporting to @1."
 msgstr "Te estas teletransportando a @1."
 
 #: init.lua
-msgid "@1 is requesting to teleport to you. /tpy to accept"
-msgstr "@1 esta pidiendo teletransportarse a ti. /tpy para aceptar"
+msgid "@1 is requesting to teleport to you. /tpy to accept."
+msgstr "@1 esta pidiendo teletransportarse a ti. /tpy para aceptar."
 
 #: init.lua
-msgid "Teleport request sent! It will timeout in @1 seconds"
-msgstr "¡Solicitud enviada! Se agotara en @1 segundos"
+msgid "Teleport request sent! It will timeout in @1 seconds."
+msgstr "¡Solicitud enviada! Se agotara en @1 segundos."
 
 #: init.lua
 msgid "Request timed-out."
@@ -69,8 +69,8 @@ msgid "Usage: /tphr <Player name>"
 msgstr "Uso: /tphr <jugador>"
 
 #: init.lua
-msgid "@1 is requesting that you teleport to them. /tpy to accept; /tpn to deny"
-msgstr "@1 esta pidiendo que tu te teletransportes a el/ella. /tpy para aceptar, /tpn para denegar"
+msgid "@1 is requesting that you teleport to them. /tpy to accept; /tpn to deny."
+msgstr "@1 esta pidiendo que tu te teletransportes a el/ella. /tpy para aceptar, /tpn para denegar."
 
 #: init.lua
 msgid "Usage: /tpc <x, y, z>"
@@ -85,8 +85,12 @@ msgid "Teleporting to: @1, @2, @3"
 msgstr "Teletransportandose a: @1, @2, @3"
 
 #: init.lua
-msgid "Error: @1 is protected by @2."
-msgstr "Error: @1 esta protegido por @2."
+msgid "Area request sent! Waiting for @1 to accept your request. It will timeout in @2 seconds."
+msgstr "Solicitud de área enviada! Esperando a @1 que acepte tu solicitud. Se agotara en @2 segundos."
+
+#: init.lua
+msgid "@1 is requesting to teleport to a protected area of yours @2."
+msgstr "@1 solicita teletransportarse a una área protegida tuya @2."
 
 #: init.lua
 msgid "Error: You do not have permission to teleport to those coordinates."
@@ -101,16 +105,24 @@ msgid "You denied the request @1 sent you."
 msgstr "Tú denegaste la solicitud de teletransporte que @1 te mando."
 
 #: init.lua
-msgid "Usage: /tpn allows you to deny teleport requests sent to you by other players."
+msgid "Usage: /tpn allows you to deny teleport/area requests sent to you by other players."
 msgstr "Uso: /tpn te permite denegar solicitudes enviadas para ti de otros jugadores."
 
 #: init.lua
-msgid "Usage: /tpy allows you to accept teleport requests sent to you by other players"
-msgstr "Uso: /tpy te permite aceptar solicitudes enviadas para ti de otros jugadores"
+msgid "Area request denied."
+msgstr "Solicitud de área denegada."
 
 #: init.lua
-msgid "@1 doesn't exist, or just disconnected/left (by timeout)."
-msgstr "@1 no existe, o se desconecto/fue."
+msgid "Usage: /tpy allows you to accept teleport/area requests sent to you by other players."
+msgstr "Uso: /tpy te permite aceptar solicitudes enviadas para ti de otros jugadores."
+
+#: init.lua
+msgid "@1 is teleporting to your protected area @2."
+msgstr "@1 se esta teletransportando a tu área protegida @2."
+
+#: init.lua
+msgid "@1 is not online right now."
+msgstr "@1 no esta en linea ahora mismo."
 
 #: init.lua
 msgid "Request Accepted!"

--- a/locale/es.po
+++ b/locale/es.po
@@ -94,15 +94,11 @@ msgstr ", o a "
 
 #: init.lua
 msgid "@1 is requesting to teleport to a protected area of yours @2."
-msgstr "@1 solicita teletransportarse a un área protegida tuya @2."
+msgstr "@1 solicita teletransportarse a una área protegida tuya @2."
 
 #: init.lua
 msgid "Error: You do not have permission to teleport to those coordinates."
 msgstr "Error: No tienes permiso para teletransportarte a esas coordenadas."
-
-#: init.lua
-msgid "Usage: /tpn allows you to deny teleport/area requests sent to you by other players."
-msgstr "Uso: /tpn te permite denegar solicitudes enviadas para ti de otros jugadores."
 
 #: init.lua
 msgid "Teleport request denied."
@@ -113,12 +109,8 @@ msgid "You denied the request @1 sent you."
 msgstr "Tú denegaste la solicitud de teletransporte que @1 te mando."
 
 #: init.lua
-msgid "You denied your request sent to @1."
-msgstr "Tú denegaste la solicitud de teletransporte enviada a @1."
-
-#: init.lua
-msgid "@1 denied their request sent to you."
-msgstr "@1 denego su solicitud de teletransporte enviada a usted."
+msgid "Usage: /tpn allows you to deny teleport/area requests sent to you by other players."
+msgstr "Uso: /tpn te permite denegar solicitudes enviadas para ti de otros jugadores."
 
 #: init.lua
 msgid "Area request denied."

--- a/locale/template.pot
+++ b/locale/template.pot
@@ -1,7 +1,7 @@
 # Template translation for Teleport Request.
 # Copyright (C) 2014-2020 ChaosWormz and contributors.
 # This file is distributed under under the same license as the Teleport Request package.
-# David Leal <halfpacho@gmail.com>, 2019.
+# David Leal <halfpacho@gmail.com>, 2019-2020.
 
 msgid ""
 msgstr ""
@@ -37,7 +37,7 @@ msgid "Usage: /tpr <Player name>"
 msgstr ""
 
 #: init.lua
-msgid "There is no player by that name. Keep in mind this is case sensitive, and the player must be online"
+msgid "There is no player by that name. Keep in mind this is case sensitive, and the player must be online."
 msgstr ""
 
 #: init.lua
@@ -49,11 +49,11 @@ msgid "You are teleporting to @1."
 msgstr ""
 
 #: init.lua
-msgid "@1 is requesting to teleport to you. /tpy to accept"
+msgid "@1 is requesting to teleport to you. /tpy to accept."
 msgstr ""
 
 #: init.lua
-msgid "Teleport request sent! It will timeout in @1 seconds"
+msgid "Teleport request sent! It will timeout in @1 seconds."
 msgstr ""
 
 #: init.lua
@@ -69,7 +69,7 @@ msgid "Usage: /tphr <Player name>"
 msgstr ""
 
 #: init.lua
-msgid "@1 is requesting that you teleport to them. /tpy to accept; /tpn to deny"
+msgid "@1 is requesting that you teleport to them. /tpy to accept; /tpn to deny."
 msgstr ""
 
 #: init.lua
@@ -85,11 +85,23 @@ msgid "Teleporting to: @1, @2, @3"
 msgstr ""
 
 #: init.lua
-msgid "Error: @1 is protected by @2."
+msgid "Area request sent! Waiting for @1 to accept your request. It will timeout in @2 seconds."
+msgstr ""
+
+#: init.lua
+msgid "@1 is requesting to teleport to a protected area of yours @2."
 msgstr ""
 
 #: init.lua
 msgid "Error: You do not have permission to teleport to those coordinates."
+msgstr ""
+
+#: init.lua
+msgid "Usage: /tpn allows you to deny teleport/area requests sent to you by other players."
+msgstr ""
+
+#: init.lua
+msgid "Area request denied."
 msgstr ""
 
 #: init.lua
@@ -101,15 +113,15 @@ msgid "You denied the request @1 sent you."
 msgstr ""
 
 #: init.lua
-msgid "Usage: /tpn allows you to deny teleport requests sent to you by other players."
+msgid "Usage: /tpy allows you to accept teleport/area requests sent to you by other players."
 msgstr ""
 
 #: init.lua
-msgid "Usage: /tpy allows you to accept teleport requests sent to you by other players"
+msgid "@1 is teleporting to your protected area @2."
 msgstr ""
 
 #: init.lua
-msgid "@1 doesn't exist, or just disconnected/left (by timeout)."
+msgid "@1 is not online right now."
 msgstr ""
 
 #: init.lua

--- a/locale/template.pot
+++ b/locale/template.pot
@@ -117,7 +117,11 @@ msgid "You denied the request @1 sent you."
 msgstr ""
 
 #: init.lua
-msgid "Usage: /tpy allows you to accept teleport/area requests sent to you by other players."
+msgid "You denied your request sent to @1."
+msgstr ""
+
+#: init.lua
+msgid "@1 denied their request sent to you."
 msgstr ""
 
 #: init.lua

--- a/locale/template.pot
+++ b/locale/template.pot
@@ -89,6 +89,10 @@ msgid "Area request sent! Waiting for @1 to accept your request. It will timeout
 msgstr ""
 
 #: init.lua
+msgid ", or "
+msgstr ""
+
+#: init.lua
 msgid "@1 is requesting to teleport to a protected area of yours @2."
 msgstr ""
 

--- a/locale/template.pot
+++ b/locale/template.pot
@@ -117,11 +117,7 @@ msgid "You denied the request @1 sent you."
 msgstr ""
 
 #: init.lua
-msgid "You denied your request sent to @1."
-msgstr ""
-
-#: init.lua
-msgid "@1 denied their request sent to you."
+msgid "Usage: /tpy allows you to accept teleport/area requests sent to you by other players."
 msgstr ""
 
 #: init.lua


### PR DESCRIPTION
Things added/changed:

- Area owners can now accept area requests from other users.
- Various message improvements.
- Translation updates.

The features above are only compatible with [`areas`](https://github.com/minetest-mods/areas).

## To do

- [x] If there are multiple area owners, the request won't be sent to any of the owners, nor any can't accept requests.
- [x] When a request is sent it doesn't checks if the area owner is online.
- [ ] If there are multiple areas, various messages will be doubled.
- [x] If an owner accepts an area request, the other requests sent to other owners will crash the server as soon as they get accepted, because `target_coords` is set to **`nil`**.

## How to test

- 1. Open 3 Minetest Engines; connect all accounts to a local server.

Let's say the first player is named `test1`.
The second is `test2`; the third is `test3`.

- 2. Now, send an area request from `test3` to `test2`; now `test2` will send a request to `test1`.

Now, accept request from `test3` to `test2`.
Accept request from `test2` `test1`.

Please test and inform me of any other issues/crashes.
If you have a bugfix, post it here or create a PR.