### PR TITLE
Senders can deny their own requests!

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -192,8 +192,10 @@ function tp.tpr_send(sender, receiver)
 
 			-- Teleport timeout delay
 			minetest.after(tp.timeout_delay, function(name)
-				if tp.tpr_list[name] then
+				if tp.tpr_list[name] and tp.tpn_list[sender] then
 					tp.tpr_list[name] = nil
+					tp.tpn_list[sender] = nil
+
 					minetest.chat_send_player(sender, S("Request timed-out."))
 					minetest.chat_send_player(receiver, S("Request timed-out."))
 
@@ -293,8 +295,10 @@ function tp.tphr_send(sender, receiver)
 
 			-- Teleport timeout delay
 			minetest.after(tp.timeout_delay, function(name)
-				if tp.tphr_list[name] then
+				if tp.tphr_list[name] and tp.tpn_list[sender] then
 					tp.tphr_list[name] = nil
+					tp.tpn_list[sender] = nil
+
 					minetest.chat_send_player(sender, S("Request timed-out."))
 					minetest.chat_send_player(receiver, S("Request timed-out."))
 

--- a/functions.lua
+++ b/functions.lua
@@ -188,6 +188,7 @@ function tp.tpr_send(sender, receiver)
 
 			-- Write name values to list and clear old values.
 			tp.tpr_list[receiver] = sender
+			tp.tpn_list[sender] = receiver
 
 			-- Teleport timeout delay
 			minetest.after(tp.timeout_delay, function(name)
@@ -288,6 +289,7 @@ function tp.tphr_send(sender, receiver)
 
 			-- Write name values to list and clear old values.
 			tp.tphr_list[receiver] = sender
+			tp.tpn_list[sender] = receiver
 
 			-- Teleport timeout delay
 			minetest.after(tp.timeout_delay, function(name)
@@ -386,7 +388,11 @@ function tp.tpr_deny(name)
 			chat2.send_message(minetest.get_player_by_name(name2), S("Teleport request denied."), 0xFFFFFF)
 			chat2.send_message(minetest.get_player_by_name(name), S("You denied the request @1 sent you.", name2), 0xFFFFFF)
 		end
+
 		tp.tpr_list[name] = nil
+
+		-- Don't allow re-denying requests.
+		tp.tpn_list[name2] = nil
 
 	elseif tp.tphr_list[name] then
 		name2 = tp.tphr_list[name]
@@ -396,8 +402,29 @@ function tp.tpr_deny(name)
 			chat2.send_message(minetest.get_player_by_name(name2), S("Teleport request denied."), 0xFFFFFF)
 			chat2.send_message(minetest.get_player_by_name(name), S("You denied the request @1 sent you.", name2), 0xFFFFFF)
 		end
+
 		tp.tphr_list[name] = nil
 
+		-- Don't allow re-denying requests.
+		tp.tpn_list[name2] = nil
+
+	elseif tp.tpn_list[name] then
+		name2 = tp.tpn_list[name]
+		minetest.chat_send_player(name, S("You denied your request sent to @1.", name2))
+		minetest.chat_send_player(name2, S("@1 denied their request sent to you.", name))
+		if minetest.get_modpath("chat2") then
+			chat2.send_message(minetest.get_player_by_name(name2), S("You denied your request sent to @1.", name), 0xFFFFFF)
+			chat2.send_message(minetest.get_player_by_name(name), S("@1 denied their request sent to you.", name2), 0xFFFFFF)
+		end
+
+		if tp.tpr_list[name2] then
+			tp.tpr_list[name2] = nil
+
+		elseif tp.tphr_list[name2] then
+			tp.tphr_list[name2] = nil
+		end
+
+		tp.tpn_list[name] = nil
 	else
 		minetest.chat_send_player(name, S("Usage: /tpn allows you to deny teleport requests sent to you by other players."))
 		if minetest.get_modpath("chat2") then
@@ -447,6 +474,12 @@ function tp.tpr_accept(name)
 	end
 
 	tp.tpr_teleport_player()
+
+	-- Don't allow re-denying requests.
+	if tp.tpn_list[name] or tp.tpn_list[name2] then
+		tp.tpn_list[name] = nil
+		tp.tpn_list[name2] = nil
+	end
 
 	minetest.chat_send_player(name, chatmsg)
 	if minetest.get_modpath("chat2") then

--- a/functions.lua
+++ b/functions.lua
@@ -417,8 +417,8 @@ function tp.tpr_deny(name)
 		minetest.chat_send_player(name, S("You denied your request sent to @1.", name2))
 		minetest.chat_send_player(name2, S("@1 denied their request sent to you.", name))
 		if minetest.get_modpath("chat2") then
-			chat2.send_message(minetest.get_player_by_name(name2), S("You denied your request sent to @1.", name), 0xFFFFFF)
-			chat2.send_message(minetest.get_player_by_name(name), S("@1 denied their request sent to you.", name2), 0xFFFFFF)
+			chat2.send_message(minetest.get_player_by_name(name), S("You denied your request sent to @1.", name2), 0xFFFFFF)
+			chat2.send_message(minetest.get_player_by_name(name2), S("@1 denied their request sent to you.", name), 0xFFFFFF)
 		end
 
 		if tp.tpr_list[name2] then

--- a/init.lua
+++ b/init.lua
@@ -33,7 +33,8 @@ local S = dofile(MP.."/intllib.lua")
 tp = {
 	intllib = S,
 	tpr_list = {},
-	tphr_list = {}
+	tphr_list = {},
+	tpn_list = {}
 }
 
 -- Clear requests when the player leaves
@@ -45,6 +46,11 @@ minetest.register_on_leaveplayer(function(name)
 
 	if tp.tphr_list[name] then
 		tp.tphr_list[name] = nil
+		return
+	end
+
+	if tp.tpn_list[name] then
+		tp.tpn_list[name] = nil
 		return
 	end
 end)

--- a/locale/es.po
+++ b/locale/es.po
@@ -1,7 +1,7 @@
 # Spanish translation for Teleport Request.
 # Copyright (C) 2014-2020 ChaosWormz and contributors.
 # This file is distributed under under the same license as the Teleport Request package.
-# David Leal <halfpacho@gmail.com>, 2019.
+# David Leal <halfpacho@gmail.com>, 2019-2020.
 
 msgid ""
 msgstr ""
@@ -99,6 +99,14 @@ msgstr "Solicitud denegada."
 #: init.lua
 msgid "You denied the request @1 sent you."
 msgstr "Tú denegaste la solicitud de teletransporte que @1 te mando."
+
+#: init.lua
+msgid "You denied your request sent to @1."
+msgstr "Tú denegaste la solicitud de teletransporte enviada a @1."
+
+#: init.lua
+msgid "@1 denied their request sent to you."
+msgstr "@1 denego su solicitud de teletransporte enviada a usted."
 
 #: init.lua
 msgid "Usage: /tpn allows you to deny teleport requests sent to you by other players."

--- a/locale/template.pot
+++ b/locale/template.pot
@@ -1,7 +1,7 @@
 # Template translation for Teleport Request.
 # Copyright (C) 2014-2020 ChaosWormz and contributors.
 # This file is distributed under under the same license as the Teleport Request package.
-# David Leal <halfpacho@gmail.com>, 2019.
+# David Leal <halfpacho@gmail.com>, 2019-2020.
 
 msgid ""
 msgstr ""
@@ -98,6 +98,14 @@ msgstr ""
 
 #: init.lua
 msgid "You denied the request @1 sent you."
+msgstr ""
+
+#: init.lua
+msgid "You denied your request sent to @1."
+msgstr ""
+
+#: init.lua
+msgid "@1 denied their request sent to you."
 msgstr ""
 
 #: init.lua


### PR DESCRIPTION
Things added/changed:

- Players can deny their own requests.

## To do
This PR is ready for review.

## How to test
- 1. Open two Minetest Engines.
- 2. Send a teleport request to a player.
- 3. Deny your own sent request.

Tested with MT 5.1.0; works perfectly.
@ChaosWormz, your review would be appreciated. 🙂