### PR TITLE
Add spam prevention

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -34,3 +34,6 @@ tp.available_places = {
 
 -- Enable tpp command
 tp.enable_tpp_command = minetest.settings:get_bool("tp.enable_tpp_command")
+
+-- Spam prevention
+tp.spam_prevention = minetest.settings:get_bool("tp.enable_spam_prevention")

--- a/functions.lua
+++ b/functions.lua
@@ -119,7 +119,7 @@ function tp.tpr_send(sender, receiver)
 	end
 
 	-- Spam prevention
-	if spam_prevention[receiver] == sender then
+	if spam_prevention[receiver] == sender and not minetest.check_player_privs(sender, {tp_admin = true}) then
 		minetest.chat_send_player(sender, S("Wait @1 seconds before you can send teleport requests to @2 again.", tp.timeout_delay, receiver))
 
 		minetest.after(tp.timeout_delay, function(name)
@@ -263,7 +263,7 @@ function tp.tphr_send(sender, receiver)
 	end
 
 	-- Spam prevention
-	if spam_prevention[receiver] == sender then
+	if spam_prevention[receiver] == sender and not minetest.check_player_privs(sender, {tp_admin = true}) then
 		minetest.chat_send_player(sender, S("Wait @1 seconds before you can send teleport requests to @2 again.", tp.timeout_delay, receiver))
 
 		minetest.after(tp.timeout_delay, function(name)

--- a/locale/es.po
+++ b/locale/es.po
@@ -29,6 +29,14 @@ msgid "Allow player to teleport to coordinates (if allowed by area protection)"
 msgstr "Permite a los jugadores teletransportarse a las coordenadas especificadas (si esta permitido por la protección de la área)"
 
 #: init.lua
+msgid "Wait @1 seconds before you can send teleport requests to @2 again."
+msgstr "Espere @1 segundos antes de que pueda mandar solicitudes de teletransporte a @2."
+
+#: init.lua
+msgid "You can now send teleport requests to @1."
+msgstr "Ya puede mandar solicitudes de teletransporte a @1."
+
+#: init.lua
 msgid "You are not allowed to send requests because you're muted."
 msgstr "No tienes permiso para mandar solicitudes de teletransporte porque estás silenciado."
 

--- a/locale/template.pot
+++ b/locale/template.pot
@@ -29,6 +29,14 @@ msgid "Allow player to teleport to coordinates (if allowed by area protection)"
 msgstr ""
 
 #: init.lua
+msgid "Wait @1 seconds before you can send teleport requests to @2 again."
+msgstr ""
+
+#: init.lua
+msgid "You can now send teleport requests to @1."
+msgstr ""
+
+#: init.lua
 msgid "You are not allowed to send requests because you're muted."
 msgstr ""
 

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -6,3 +6,6 @@ tp.enable_immediate_teleport (Immediate teleport for those with tp_admin privile
 
 # Enables Teleport To Place command (disabled by default)
 tp.enable_tpp_command (Enable Teleport To Place command) bool false
+
+# Spam prevention (enabled by default)
+tp.enable_spam_prevention (Enable spam prevention) bool true


### PR DESCRIPTION
Closes #36.
Things added/changed:
- Add spam prevention.
  - Users wont be able send requests after 60 seconds to the same player after it has been denied.

## To do
Ready for review.

## How to test
1. - Send a request to a player.
2. - Deny the request sent from that player.
3. - Try to send a request to that same player.