### PR TITLE
Allow muting other players' teleport requests

### DIFF
--- a/commands.lua
+++ b/commands.lua
@@ -66,3 +66,17 @@ minetest.register_chatcommand("tpn", {
 	privs = {interact = true, tp = true},
 	func = tp.tpr_deny
 })
+
+minetest.register_chatcommand("tpr_mute", {
+	description = S("Mutes a player: denies them from sending you teleport requests"),
+	params = S("<playername> | leave playername empty to see help message"),
+	privs = {interact = true, tp = true},
+	func = tp.tpr_mute
+})
+
+minetest.register_chatcommand("tpr_unmute", {
+	description = S("Unmutes a player: allow them to send you teleport requests again"),
+	params = S("<playername> | leave playername empty to see help message"),
+	privs = {interact = true, tp = true},
+	func = tp.tpr_unmute
+})

--- a/locale/es.po
+++ b/locale/es.po
@@ -29,6 +29,14 @@ msgid "Allow player to teleport to coordinates (if allowed by area protection)"
 msgstr "Permite a los jugadores teletransportarse a las coordenadas especificadas (si esta permitido por la protección de la área)"
 
 #: init.lua
+msgid "Usage: /tpr_mute <player>"
+msgstr "Uso: /tpr_mute <jugador>"
+
+#: init.lua
+msgid "tpr_mute: Failed to mute player @1: they have the tp_admin privilege."
+msgstr "tpr_mute: No se pudo silenciar al jugador @1: tiene el privilegio tp_admin."
+
+#: init.lua
 msgid "Wait @1 seconds before you can send teleport requests to @2 again."
 msgstr "Espere @1 segundos antes de que pueda mandar solicitudes de teletransporte a @2."
 
@@ -39,6 +47,30 @@ msgstr "Ya puede mandar solicitudes de teletransporte a @1."
 #: init.lua
 msgid "You are not allowed to send requests because you're muted."
 msgstr "No tienes permiso para mandar solicitudes de teletransporte porque estás silenciado."
+
+#: init.lua
+msgid "Cannot send request to @1 (you have been muted)."
+msgstr "No se puede enviar la solicitud a @1 (has sido silenciado)."
+
+#: init.lua
+msgid "tpr_mute: Player @1 is already muted."
+msgstr "tpr_mute: El jugador @1 ya esta silenciado."
+
+#: init.lua
+msgid "tpr_mute: Player @1 successfully muted."
+msgstr "tpr_mute: El jugador @1 ha sido silenciado con éxito."
+
+#: init.lua
+msgid "Usage: /tpr_unmute <player>"
+msgstr "Uso: /tpr_unmute <player>"
+
+#: init.lua
+msgid "tpr_mute: Player @1 is not muted yet."
+msgstr "tpr_mute: El jugador @1 aún no ha sido slienciado."
+
+#: init.lua
+msgid "tpr_mute: Player @1 successfully unmuted."
+msgstr "tpr_mute: El sonido del jugador @1 ha sido activado con éxito."
 
 #: init.lua
 msgid "Usage: /tpr <Player name>"
@@ -226,6 +258,14 @@ msgstr "Aceptar solicitudes de otro jugador."
 #: init.lua
 msgid "Deny teleport requests from another player"
 msgstr "Denegar solicitudos de otro jugador."
+
+#: init.lua
+msgid "Mutes a player: denies them from sending you teleport requests"
+msgstr "Silencia a un jugador: le niega el envío de solicitudes de teletransporte"
+
+#: init.lua
+msgid "Unmutes a player: allow them to send you teleport requests again"
+msgstr "Activar el sonido de un jugador: permite que te envíe solicitudes de teletransporte nuevamente"
 
 #: init.lua
 msgid "[Teleport Request] TPS Teleport v@1 Loaded!"

--- a/locale/pt_BR.po
+++ b/locale/pt_BR.po
@@ -29,8 +29,36 @@ msgid "Allow player to teleport to coordinates (if allowed by area protection)"
 msgstr "Permitir que o jogador se teletransporte para coordenadas (se permitido pela protecao da area)"
 
 #: init.lua
+msgid "tpr_mute: Failed to mute player @1: they have the tp_admin privilege."
+msgstr ""
+
+#: init.lua
 msgid "You are not allowed to send requests because you're muted."
 msgstr "Voce nao tem permissao para enviar solicitacoes porque esta' sem som."
+
+#: init.lua
+msgid "Cannot send request to @1 (you have been muted)."
+msgstr ""
+
+#: init.lua
+msgid "tpr_mute: Player @1 is already muted."
+msgstr ""
+
+#: init.lua
+msgid "tpr_mute: Player @1 successfully muted."
+msgstr ""
+
+#: init.lua
+msgid "Usage: /tpr_unmute <player>"
+msgstr ""
+
+#: init.lua
+msgid "tpr_mute: Player @1 is not muted yet."
+msgstr ""
+
+#: init.lua
+msgid "tpr_mute: Player @1 successfully unmuted."
+msgstr ""
 
 #: init.lua
 msgid "Usage: /tpr <Player name>"
@@ -203,6 +231,14 @@ msgstr "Aceitar pedidos de teleporte de outro jogador"
 #: init.lua
 msgid "Deny teleport requests from another player"
 msgstr "Negar pedidos de teleporte de outro jogador"
+
+#: init.lua
+msgid "Mutes a player: denies them from sending you teleport requests"
+msgstr ""
+
+#: init.lua
+msgid "Unmutes a player: allow them to send you teleport requests again"
+msgstr ""
 
 #: init.lua
 msgid "[Teleport Request] TPS Teleport v@1 Loaded!"

--- a/locale/template.pot
+++ b/locale/template.pot
@@ -29,6 +29,10 @@ msgid "Allow player to teleport to coordinates (if allowed by area protection)"
 msgstr ""
 
 #: init.lua
+msgid "tpr_mute: Failed to mute player @1: they have the tp_admin privilege."
+msgstr ""
+
+#: init.lua
 msgid "Wait @1 seconds before you can send teleport requests to @2 again."
 msgstr ""
 
@@ -38,6 +42,30 @@ msgstr ""
 
 #: init.lua
 msgid "You are not allowed to send requests because you're muted."
+msgstr ""
+
+#: init.lua
+msgid "Cannot send request to @1 (you have been muted)."
+msgstr ""
+
+#: init.lua
+msgid "tpr_mute: Player @1 is already muted."
+msgstr ""
+
+#: init.lua
+msgid "tpr_mute: Player @1 successfully muted."
+msgstr ""
+
+#: init.lua
+msgid "Usage: /tpr_unmute <player>"
+msgstr ""
+
+#: init.lua
+msgid "tpr_mute: Player @1 is not muted yet."
+msgstr ""
+
+#: init.lua
+msgid "tpr_mute: Player @1 successfully unmuted."
 msgstr ""
 
 #: init.lua
@@ -225,6 +253,14 @@ msgstr ""
 
 #: init.lua
 msgid "Deny teleport requests from another player"
+msgstr ""
+
+#: init.lua
+msgid "Mutes a player: denies them from sending you teleport requests"
+msgstr ""
+
+#: init.lua
+msgid "Unmutes a player: allow them to send you teleport requests again"
 msgstr ""
 
 #: init.lua


### PR DESCRIPTION
Closes #38.
Things added/changed:

- Added `tpr_mute` command to mute other players' teleport requests.
- Updated template translation and Spanish translations.

## To do

Ready for review.

## How to test

- Connect with two players.
- Do `/tpr_mute <player_name>`.
- Try to send a teleport request to the player who muted you.
- Unmute the player using `/tpr_unmute <player_name>`.
- Send a teleport request.
